### PR TITLE
optimize Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,9 @@ COPY --from=build /go/bin/recs4m /bin/
 COPY ./html /
 COPY ./upload.sh /root
 
-RUN apt-get install -y language-pack-ja && \
+RUN apt-get update && \
+    apt-get install -y language-pack-ja && \
+    rm -rf /var/lib/apt/lists/* && \
     chmod +x /root/upload.sh
 
 EXPOSE 80


### PR DESCRIPTION
Hi cs3238-tsuzu:

modified Dockerfile a little, just  reduce the image size

in Dockerfile, when you clean up the apt cache by removing /var/lib/apt/lists it reduces the image size, since the apt cache is not stored in a layer.  [docker docs](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run)